### PR TITLE
ベストビット・ベストアスクの算出方法を改善

### DIFF
--- a/lib/logic.js
+++ b/lib/logic.js
@@ -55,9 +55,10 @@ module.exports.trade = function() {
       // 新規注文
       var bestBid = parseFloat(cache.get("best_bid"));
       var bestAsk = parseFloat(cache.get("best_ask"));
-      var spread = (bestBid + bestAsk) * 0.5 * spreadPercentage;
-      var buyPrice = parseFloat(bestBid - spread);
-      var sellPrice = parseFloat(bestAsk + spread);
+      var average =  (bestBid + bestAsk) * 0.5
+      var spread = average * spreadPercentage;
+      var buyPrice = parseFloat(average - spread);
+      var sellPrice = parseFloat(average + spread);
 
       if(xrpAvailable > maxHoldXrp) {
         callback("BTC amount is over the threthold.", null);


### PR DESCRIPTION
### 概要
@yuma300 

既存のプライス算出方法の場合、ベストビット・ベストアスクの外側の値段で発注することができるが、その場合、約定する機会に乏しい。

そこで既存のベストビット・ベストアスクの内側の値段帯で発注する（ベストビット・ベストアスクに成り替わる）ロジックを採用し、約定機会の増加を期待できるようにした。